### PR TITLE
Fix tsc errors and refine typings

### DIFF
--- a/client/src/components/advanced-playlist-editor.tsx
+++ b/client/src/components/advanced-playlist-editor.tsx
@@ -8,6 +8,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { type Track, type PlaylistWithTracks } from "@shared/schema";
 import { 
   ArrowUpDown, 
   Zap, 
@@ -23,29 +24,9 @@ import {
   Volume2
 } from "lucide-react";
 
-interface Track {
-  id: number;
-  spotifyId: string;
-  name: string;
-  artist: string;
-  album: string;
-  duration: number;
-  energy?: number;
-  danceability?: number;
-  valence?: number;
-  tempo?: number;
-  popularity?: number;
-  acousticness?: number;
-  instrumentalness?: number;
-  liveness?: number;
-  speechiness?: number;
-  loudness?: number;
-  position: number;
-}
-
 interface AdvancedPlaylistEditorProps {
-  playlist: any;
-  onPlaylistUpdate: (playlist: any) => void;
+  playlist: PlaylistWithTracks;
+  onPlaylistUpdate: (playlist: PlaylistWithTracks) => void;
 }
 
 export default function AdvancedPlaylistEditor({ playlist, onPlaylistUpdate }: AdvancedPlaylistEditorProps) {
@@ -345,7 +326,9 @@ export default function AdvancedPlaylistEditor({ playlist, onPlaylistUpdate }: A
                     </label>
                     <Slider
                       value={energyFilter}
-                      onValueChange={setEnergyFilter}
+                      onValueChange={(val) =>
+                        setEnergyFilter(val as [number, number])
+                      }
                       max={1}
                       min={0}
                       step={0.1}
@@ -359,7 +342,9 @@ export default function AdvancedPlaylistEditor({ playlist, onPlaylistUpdate }: A
                     </label>
                     <Slider
                       value={bpmFilter}
-                      onValueChange={setBpmFilter}
+                      onValueChange={(val) =>
+                        setBpmFilter(val as [number, number])
+                      }
                       max={200}
                       min={60}
                       step={1}
@@ -373,7 +358,9 @@ export default function AdvancedPlaylistEditor({ playlist, onPlaylistUpdate }: A
                     </label>
                     <Slider
                       value={moodFilter}
-                      onValueChange={setMoodFilter}
+                      onValueChange={(val) =>
+                        setMoodFilter(val as [number, number])
+                      }
                       max={1}
                       min={0}
                       step={0.1}

--- a/client/src/components/playlist-display.tsx
+++ b/client/src/components/playlist-display.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import TrackList from "@/components/track-list";
 import PlaylistActions from "@/components/playlist-actions";
 import PlaylistEditor from "@/components/playlist-editor";
+import { type PlaylistWithTracks } from "@shared/schema";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -11,9 +12,11 @@ import { useToast } from "@/hooks/use-toast";
 export default function PlaylistDisplay() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const [playlistState, setPlaylistState] = useState<any>(null);
+  const [playlistState, setPlaylistState] = useState<PlaylistWithTracks | null>(
+    null
+  );
 
-  const { data: currentPlaylist, isLoading } = useQuery({
+  const { data: currentPlaylist, isLoading } = useQuery<PlaylistWithTracks | null>({
     queryKey: ["/api/playlists", "current"],
     enabled: false,
   });
@@ -102,7 +105,7 @@ export default function PlaylistDisplay() {
           <div className="flex items-center space-x-3">
             <Button
               onClick={() => saveToSpotify.mutate(currentPlaylist.id)}
-              disabled={saveToSpotify.isPending || currentPlaylist.spotifyId}
+              disabled={saveToSpotify.isPending || !!currentPlaylist.spotifyId}
               className="spotify-green hover:bg-green-600 text-white px-6 py-2 rounded-full font-medium transition-colors"
             >
               <i className="fas fa-plus mr-2"></i>

--- a/client/src/components/playlist-editor.tsx
+++ b/client/src/components/playlist-editor.tsx
@@ -13,9 +13,11 @@ interface EditMessage {
   changes?: string[];
 }
 
+import { type PlaylistWithTracks } from "@shared/schema";
+
 interface PlaylistEditorProps {
-  playlistId: number;
-  onPlaylistUpdate: (playlist: any) => void;
+  playlist: PlaylistWithTracks;
+  onPlaylistUpdate: (playlist: PlaylistWithTracks) => void;
 }
 
 const EXAMPLE_COMMANDS = [
@@ -31,7 +33,7 @@ const EXAMPLE_COMMANDS = [
   "Make this sound like a coffee shop playlist"
 ];
 
-export default function PlaylistEditor({ playlistId, onPlaylistUpdate }: PlaylistEditorProps) {
+export default function PlaylistEditor({ playlist, onPlaylistUpdate }: PlaylistEditorProps) {
   const [command, setCommand] = useState("");
   const [messages, setMessages] = useState<EditMessage[]>([]);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -41,11 +43,12 @@ export default function PlaylistEditor({ playlistId, onPlaylistUpdate }: Playlis
 
   const editPlaylist = useMutation({
     mutationFn: async (command: string) => {
-      const response = await apiRequest(`/api/playlists/${playlistId}/edit`, {
-        method: "POST",
-        body: { command },
-      });
-      return response;
+      const response = await apiRequest(
+        "POST",
+        `/api/playlists/${playlist.id}/edit`,
+        { command }
+      );
+      return response.json();
     },
     onSuccess: (data) => {
       const assistantMessage: EditMessage = {

--- a/client/src/components/recently-played.tsx
+++ b/client/src/components/recently-played.tsx
@@ -14,7 +14,7 @@ interface SpotifyTrack {
 }
 
 export default function RecentlyPlayed() {
-  const { data: recentlyPlayed, isLoading } = useQuery({
+  const { data: recentlyPlayed, isLoading } = useQuery<SpotifyTrack[]>({
     queryKey: ["/api/spotify/recently-played"],
     retry: false,
   });

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -10,13 +10,13 @@ interface SidebarProps {
 export default function Sidebar({ playlists, recentPrompts }: SidebarProps) {
   const [location] = useLocation();
 
-  const { data: spotifyPlaylists } = useQuery({
+  const { data: spotifyPlaylists } = useQuery<any[]>({
     queryKey: ["/api/spotify/playlists"],
     retry: false,
     refetchOnWindowFocus: false,
   });
 
-  const { data: recentlyPlayed } = useQuery({
+  const { data: recentlyPlayed } = useQuery<any[]>({
     queryKey: ["/api/spotify/recently-played"],
     retry: false,
     refetchOnWindowFocus: false,

--- a/client/src/components/spotify-playlists.tsx
+++ b/client/src/components/spotify-playlists.tsx
@@ -11,7 +11,7 @@ interface SpotifyPlaylist {
 }
 
 export default function SpotifyPlaylists() {
-  const { data: spotifyPlaylists, isLoading } = useQuery({
+  const { data: spotifyPlaylists, isLoading } = useQuery<SpotifyPlaylist[]>({
     queryKey: ["/api/spotify/playlists"],
     retry: false,
   });

--- a/client/src/components/track-list.tsx
+++ b/client/src/components/track-list.tsx
@@ -2,9 +2,10 @@ import { type Track } from "@shared/schema";
 
 interface TrackListProps {
   tracks: Track[];
+  showArtwork?: boolean;
 }
 
-export default function TrackList({ tracks }: TrackListProps) {
+export default function TrackList({ tracks, showArtwork }: TrackListProps) {
   const formatDuration = (ms: number) => {
     const minutes = Math.floor(ms / 60000);
     const seconds = Math.floor((ms % 60000) / 1000);
@@ -28,11 +29,16 @@ export default function TrackList({ tracks }: TrackListProps) {
             <span className="group-hover:hidden text-sm">{index + 1}</span>
             <i className="fas fa-play hidden group-hover:block text-sm"></i>
           </div>
-          <img 
-            src={track.imageUrl || "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f?ixlib=rb-4.0.3&auto=format&fit=crop&w=40&h=40"} 
-            alt="Track artwork" 
-            className="w-10 h-10 rounded ml-4 object-cover"
-          />
+          {showArtwork !== false && (
+            <img
+              src={
+                track.imageUrl ||
+                "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f?ixlib=rb-4.0.3&auto=format&fit=crop&w=40&h=40"
+              }
+              alt="Track artwork"
+              className="w-10 h-10 rounded ml-4 object-cover"
+            />
+          )}
           <div className="ml-4 flex-1">
             <p className="text-white font-medium">{track.name}</p>
             <p className="text-gray-400 text-sm">{track.artist}</p>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { type User, type Playlist, type RecentPrompt } from "@shared/schema";
 import { useLocation } from "wouter";
 import { useEffect } from "react";
 import { useToast } from "@/hooks/use-toast";
@@ -11,17 +12,17 @@ export default function Home() {
   const [location] = useLocation();
   const { toast } = useToast();
 
-  const { data: user, isLoading: userLoading } = useQuery({
+  const { data: user, isLoading: userLoading } = useQuery<User | null>({
     queryKey: ["/api/auth/me"],
     retry: false,
   });
 
-  const { data: playlists, isLoading: playlistsLoading } = useQuery({
+  const { data: playlists, isLoading: playlistsLoading } = useQuery<Playlist[]>({
     queryKey: ["/api/playlists"],
     enabled: !!user,
   });
 
-  const { data: recentPrompts } = useQuery({
+  const { data: recentPrompts } = useQuery<RecentPrompt[]>({
     queryKey: ["/api/recent-prompts"],
     enabled: !!user,
   });
@@ -82,7 +83,12 @@ export default function Home() {
     <div className="min-h-screen flex">
       <Sidebar playlists={playlists || []} recentPrompts={recentPrompts || []} />
       <main className="flex-1 ml-64 p-8">
-        <Header user={user} />
+        <Header
+          user={{
+            displayName: user.displayName,
+            imageUrl: user.imageUrl || undefined,
+          }}
+        />
         <div className="grid grid-cols-1 xl:grid-cols-3 gap-8">
           {/* Left Column - Main Content */}
           <div className="xl:col-span-2">

--- a/client/src/pages/maximalist-home.tsx
+++ b/client/src/pages/maximalist-home.tsx
@@ -1,5 +1,11 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import {
+  type User,
+  type Playlist,
+  type RecentPrompt,
+  type PlaylistWithTracks,
+} from "@shared/schema";
 import { useLocation } from "wouter";
 import { useEffect } from "react";
 import { useToast } from "@/hooks/use-toast";
@@ -9,30 +15,40 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import PlaylistGenerator from "@/components/playlist-generator";
 import TrackList from "@/components/track-list";
-import { Music, Sparkles, History, Library, Settings, User, Zap } from "lucide-react";
+import {
+  Music,
+  Sparkles,
+  History,
+  Library,
+  Settings,
+  User as UserIcon,
+  Zap,
+} from "lucide-react";
 
 export default function MaximalistHome() {
   const [location] = useLocation();
   const { toast } = useToast();
-  const [currentPlaylist, setCurrentPlaylist] = useState<any>(null);
+  const [currentPlaylist, setCurrentPlaylist] = useState<PlaylistWithTracks | null>(
+    null
+  );
   const [activeTab, setActiveTab] = useState("generate");
 
-  const { data: user, isLoading: userLoading } = useQuery({
+  const { data: user, isLoading: userLoading } = useQuery<User | null>({
     queryKey: ["/api/auth/me"],
     retry: false,
   });
 
-  const { data: playlists, isLoading: playlistsLoading } = useQuery({
+  const { data: playlists, isLoading: playlistsLoading } = useQuery<Playlist[]>({
     queryKey: ["/api/playlists"],
     enabled: !!user,
   });
 
-  const { data: recentPrompts } = useQuery({
+  const { data: recentPrompts } = useQuery<RecentPrompt[]>({
     queryKey: ["/api/recent-prompts"],
     enabled: !!user,
   });
 
-  const { data: spotifyPlaylists } = useQuery({
+  const { data: spotifyPlaylists } = useQuery<any[]>({
     queryKey: ["/api/spotify/playlists"],
     enabled: !!user,
   });
@@ -232,8 +248,8 @@ export default function MaximalistHome() {
                         <div className="animate-spin w-6 h-6 border-2 border-purple-500 border-t-transparent rounded-full mx-auto"></div>
                         <p className="text-gray-400 text-sm mt-2">Loading playlists...</p>
                       </div>
-                    ) : playlists?.length > 0 ? (
-                      playlists.map((playlist: any) => (
+                    ) : playlists && playlists.length > 0 ? (
+                      playlists.map((playlist: Playlist) => (
                         <Card key={playlist.id} className="bg-gray-800/50 border-gray-700 hover:bg-gray-700/50 cursor-pointer transition-colors" onClick={() => handlePlaylistClick(playlist)}>
                           <CardContent className="p-3">
                             <p className="text-white text-sm font-medium">{playlist.name}</p>
@@ -256,8 +272,8 @@ export default function MaximalistHome() {
                 <div className="space-y-4">
                   <h3 className="text-white font-semibold">Recent Prompts</h3>
                   <div className="space-y-2">
-                    {recentPrompts?.length > 0 ? (
-                      recentPrompts.map((prompt: any) => (
+                    {recentPrompts && recentPrompts.length > 0 ? (
+                      recentPrompts.map((prompt: RecentPrompt) => (
                         <Card key={prompt.id} className="bg-gray-800/50 border-gray-700 hover:bg-gray-700/50 cursor-pointer transition-colors" onClick={() => handlePromptClick(prompt.prompt)}>
                           <CardContent className="p-3">
                             <p className="text-white text-sm">{prompt.prompt}</p>

--- a/server/services/playlist-editor.ts
+++ b/server/services/playlist-editor.ts
@@ -97,7 +97,9 @@ export class PlaylistEditor {
         const afterYear = command.parameters.after_year;
         const beforeCount = filteredTracks.length;
         filteredTracks = filteredTracks.filter(track => {
-          const year = new Date(track.releaseDate).getFullYear();
+          const year = track.releaseDate
+            ? new Date(track.releaseDate).getFullYear()
+            : 0;
           if (beforeYear && year < beforeYear) return false;
           if (afterYear && year > afterYear) return false;
           return true;
@@ -108,9 +110,11 @@ export class PlaylistEditor {
       case 'remove_by_genre':
         const excludeGenres = command.parameters.exclude_genres || [];
         const beforeGenreCount = filteredTracks.length;
-        filteredTracks = filteredTracks.filter(track => 
-          !excludeGenres.some((genre: string) => 
-            track.genres?.some(g => g.toLowerCase().includes(genre.toLowerCase()))
+        filteredTracks = filteredTracks.filter(track =>
+          !excludeGenres.some((genre: string) =>
+            (track.genres as string[] | undefined)?.some((g: string) =>
+              g.toLowerCase().includes(genre.toLowerCase())
+            )
           )
         );
         changes.push(`Removed ${beforeGenreCount - filteredTracks.length} tracks from excluded genres`);
@@ -191,8 +195,8 @@ export class PlaylistEditor {
 
       case 'sort_by_year':
         sortedTracks.sort((a, b) => {
-          const yearA = new Date(a.releaseDate).getFullYear();
-          const yearB = new Date(b.releaseDate).getFullYear();
+          const yearA = a.releaseDate ? new Date(a.releaseDate).getFullYear() : 0;
+          const yearB = b.releaseDate ? new Date(b.releaseDate).getFullYear() : 0;
           return yearB - yearA;
         });
         changes.push('Sorted by release year (newest first)');

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -157,3 +157,7 @@ export type Track = typeof tracks.$inferSelect;
 export type InsertTrack = z.infer<typeof insertTrackSchema>;
 export type RecentPrompt = typeof recentPrompts.$inferSelect;
 export type InsertRecentPrompt = z.infer<typeof insertRecentPromptSchema>;
+
+export interface PlaylistWithTracks extends Playlist {
+  tracks: Track[];
+}


### PR DESCRIPTION
## Summary
- ensure playlist and track types are shared between server and client
- make playlist editor and advanced editor type safe
- add optional artwork prop to track list
- fix API calls and null handling in UI components
- correct server playlist editor date parsing

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68794b9c8d4c8331aeabbdf7f58045e8