### PR TITLE
Fix null handling in playlist editor filters

### DIFF
--- a/server/services/playlist-editor.ts
+++ b/server/services/playlist-editor.ts
@@ -97,7 +97,9 @@ export class PlaylistEditor {
         const afterYear = command.parameters.after_year;
         const beforeCount = filteredTracks.length;
         filteredTracks = filteredTracks.filter(track => {
-          const year = new Date(track.releaseDate).getFullYear();
+          const year = track.releaseDate
+            ? new Date(track.releaseDate).getFullYear()
+            : 0;
           if (beforeYear && year < beforeYear) return false;
           if (afterYear && year > afterYear) return false;
           return true;
@@ -108,11 +110,12 @@ export class PlaylistEditor {
       case 'remove_by_genre':
         const excludeGenres = command.parameters.exclude_genres || [];
         const beforeGenreCount = filteredTracks.length;
-        filteredTracks = filteredTracks.filter(track => 
-          !excludeGenres.some((genre: string) => 
-            track.genres?.some(g => g.toLowerCase().includes(genre.toLowerCase()))
-          )
-        );
+        filteredTracks = filteredTracks.filter(track => {
+          const genres = Array.isArray(track.genres) ? track.genres : [];
+          return !excludeGenres.some((genre: string) =>
+            genres.some(g => g.toLowerCase().includes(genre.toLowerCase()))
+          );
+        });
         changes.push(`Removed ${beforeGenreCount - filteredTracks.length} tracks from excluded genres`);
         break;
 
@@ -189,12 +192,12 @@ export class PlaylistEditor {
         changes.push('Sorted by energy level (high to low)');
         break;
 
-      case 'sort_by_year':
-        sortedTracks.sort((a, b) => {
-          const yearA = new Date(a.releaseDate).getFullYear();
-          const yearB = new Date(b.releaseDate).getFullYear();
-          return yearB - yearA;
-        });
+        case 'sort_by_year':
+          sortedTracks.sort((a, b) => {
+            const yearA = a.releaseDate ? new Date(a.releaseDate).getFullYear() : 0;
+            const yearB = b.releaseDate ? new Date(b.releaseDate).getFullYear() : 0;
+            return yearB - yearA;
+          });
         changes.push('Sorted by release year (newest first)');
         break;
 


### PR DESCRIPTION
## Summary
- handle optional releaseDate & genres fields in playlist editor
- safeguard sorting by year when release dates may be null

## Testing
- `npm run check` *(fails: Property 'slice' does not exist on type '{}' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879462e43108331b2fffb05641d6eb3