### PR TITLE
Add simple AI playlist generator example

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
+    "cors": "^2.8.5",
     "date-fns": "^3.6.0",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
@@ -98,14 +99,14 @@
     "@vitejs/plugin-react": "^4.3.2",
     "autoprefixer": "^10.4.20",
     "drizzle-kit": "^0.30.4",
+    "electron": "^30.0.0",
+    "electron-builder": "^24.6.0",
     "esbuild": "^0.25.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.19",
-    "electron": "^30.0.0",
-    "electron-builder": "^24.6.0"
+    "vite": "^5.4.19"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/simple-server.js
+++ b/server/simple-server.js
@@ -1,0 +1,82 @@
+const express = require('express');
+const cors = require('cors');
+const OpenAI = require('openai');
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+async function getSpotifyToken() {
+  const creds = Buffer.from(`${process.env.SPOTIFY_CLIENT_ID}:${process.env.SPOTIFY_CLIENT_SECRET}`).toString('base64');
+  const res = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Basic ${creds}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: 'grant_type=client_credentials'
+  });
+  if (!res.ok) {
+    throw new Error('Failed to get Spotify token');
+  }
+  const data = await res.json();
+  return data.access_token;
+}
+
+function msToMin(ms) {
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000).toString().padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}
+
+async function analyzePrompt(prompt) {
+  const system = `You extract musical preferences from a user prompt. ` +
+    `Return JSON with fields: genres (array of up to 5), mood (string), energy (0-1 number).`;
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: prompt }
+    ],
+    response_format: { type: 'json_object' },
+    temperature: 0.7
+  });
+  const json = JSON.parse(completion.choices[0].message.content);
+  return json;
+}
+
+app.post('/generate', async (req, res) => {
+  const { prompt } = req.body || {};
+  if (!prompt || !prompt.trim()) {
+    return res.status(400).json({ message: 'Prompt required' });
+  }
+  try {
+    const params = await analyzePrompt(prompt);
+    const token = await getSpotifyToken();
+    const query = new URLSearchParams({
+      limit: '10',
+      seed_genres: (params.genres || []).slice(0,5).join(',') || 'pop',
+      target_energy: params.energy || 0.5
+    });
+    const recRes = await fetch('https://api.spotify.com/v1/recommendations?' + query.toString(), {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!recRes.ok) throw new Error('Spotify recommendations failed');
+    const recData = await recRes.json();
+    const tracks = recData.tracks.map(t => ({
+      title: t.name,
+      artist: t.artists.map(a => a.name).join(', '),
+      spotify_url: t.external_urls.spotify,
+      cover_url: t.album.images[0]?.url,
+      duration: msToMin(t.duration_ms)
+    }));
+    res.json({ playlist_url: null, tracks });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to generate playlist' });
+  }
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => console.log(`server listening on ${port}`));

--- a/simple-client/index.html
+++ b/simple-client/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Playlist Generator</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module" src="/src/main.jsx"></script>
+  </head>
+  <body class="min-h-screen bg-gray-950 text-white flex items-center justify-center">
+    <div id="root"></div>
+  </body>
+</html>

--- a/simple-client/src/App.jsx
+++ b/simple-client/src/App.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import PromptForm from './PromptForm.jsx';
+import TrackCard from './TrackCard.jsx';
+import { generatePlaylist } from './api.js';
+
+export default function App() {
+  const [tracks, setTracks] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const handleSubmit = async (prompt) => {
+    if (!prompt) return;
+    setLoading(true);
+    try {
+      const data = await generatePlaylist(prompt);
+      setTracks(data.tracks);
+    } catch (err) {
+      alert('Failed to generate playlist');
+    } finally {
+      setLoading(false);
+    }
+  };
+  return (
+    <div className="w-full max-w-xl space-y-4">
+      <PromptForm onSubmit={handleSubmit} loading={loading} />
+      <div className="space-y-2">
+        {tracks.map((t, i) => (
+          <TrackCard key={i} track={t} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/simple-client/src/PromptForm.jsx
+++ b/simple-client/src/PromptForm.jsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+
+export default function PromptForm({ onSubmit, loading }) {
+  const [value, setValue] = useState('');
+  const handle = (e) => {
+    e.preventDefault();
+    onSubmit(value);
+  };
+  return (
+    <form onSubmit={handle} className="flex">
+      <input
+        className="flex-1 p-2 rounded-l bg-gray-800 text-white"
+        placeholder="Describe your playlist..."
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <button
+        type="submit"
+        disabled={loading}
+        className="px-4 bg-green-500 text-white rounded-r disabled:opacity-50"
+      >
+        {loading ? '...' : 'Generate'}
+      </button>
+    </form>
+  );
+}

--- a/simple-client/src/TrackCard.jsx
+++ b/simple-client/src/TrackCard.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function TrackCard({ track }) {
+  return (
+    <div className="flex items-center space-x-3 bg-gray-800 p-2 rounded">
+      <img src={track.cover_url} alt="cover" className="w-12 h-12 object-cover" />
+      <div className="flex-1">
+        <p className="font-medium">{track.title}</p>
+        <p className="text-sm text-gray-400">{track.artist}</p>
+      </div>
+      <a href={track.spotify_url} target="_blank" rel="noreferrer" className="text-green-400">
+        Open
+      </a>
+    </div>
+  );
+}

--- a/simple-client/src/api.js
+++ b/simple-client/src/api.js
@@ -1,0 +1,9 @@
+export async function generatePlaylist(prompt) {
+  const res = await fetch('http://localhost:3001/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt })
+  });
+  if (!res.ok) throw new Error('API error');
+  return res.json();
+}

--- a/simple-client/src/main.jsx
+++ b/simple-client/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- add Express server in `server/simple-server.js` with `/generate` route
- install `cors`
- add minimal React front-end under `simple-client`

## Testing
- `npm run check` *(fails: server/routes.ts error TS2495, server/services/spotify.ts duplicate function implementation)*

------
https://chatgpt.com/codex/tasks/task_e_68795d40e7648331a4d219fd5b70bebc