### PR TITLE
Fix compile errors in Spotify service

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -143,7 +143,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const deduped = tracks.filter((t, i, self) => i === self.findIndex(x => x.id === t.id));
 
       // Validate audio features
-      const features = await spotifyService.getAudioFeatures(user.accessToken, deduped.map(t => t.id));
+      const features = await spotifyService.getAudioFeaturesMap(user.accessToken, deduped.map(t => t.id));
       const filtered = deduped.filter(t => {
         const af = features[t.id];
         if (!af) return true;

--- a/server/services/spotify.ts
+++ b/server/services/spotify.ts
@@ -163,7 +163,7 @@ export class SpotifyService {
     return data.tracks;
   }
 
-  async getAudioFeatures(accessToken: string, trackIds: string[]): Promise<Record<string, any>> {
+  async getAudioFeaturesMap(accessToken: string, trackIds: string[]): Promise<Record<string, any>> {
     if (trackIds.length === 0) return {};
     const idChunks: string[][] = [];
     for (let i = 0; i < trackIds.length; i += 100) {


### PR DESCRIPTION
## Summary
- remove duplicate `getAudioFeatures` by introducing `getAudioFeaturesMap`
- update server routes to call the renamed function

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68795ea8099c83318ad1842a4ebcc5ba