### PR TITLE
Add add-similar action

### DIFF
--- a/client/src/components/playlist-actions.tsx
+++ b/client/src/components/playlist-actions.tsx
@@ -1,24 +1,57 @@
 import { Button } from "@/components/ui/button";
 import { type Playlist } from "@shared/schema";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
 
 interface PlaylistActionsProps {
   currentPlaylist: Playlist & { tracks: any[] };
 }
 
 export default function PlaylistActions({ currentPlaylist }: PlaylistActionsProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const addSimilarSongs = useMutation({
+    mutationFn: async () => {
+      const res = await apiRequest(
+        "POST",
+        `/api/playlists/${currentPlaylist.id}/add-similar`
+      );
+      return res.json();
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(["/api/playlists", "current"], data.playlist);
+      toast({
+        title: "Added similar songs",
+        description: data.reasoning || "New tracks have been appended",
+      });
+    },
+    onError: (err: any) => {
+      toast({
+        title: "Failed to add songs",
+        description: err.message,
+        variant: "destructive",
+      });
+    },
+  });
+
   const handleAddSimilarSongs = () => {
-    // TODO: Implement add similar songs functionality
-    console.log("Add similar songs for playlist:", currentPlaylist.id);
+    addSimilarSongs.mutate();
   };
 
   const handleReplaceOverplayed = () => {
-    // TODO: Implement replace overplayed functionality
-    console.log("Replace overplayed songs for playlist:", currentPlaylist.id);
+    toast({
+      title: "Not implemented",
+      description: "Replace overplayed is coming soon",
+    });
   };
 
   const handleReorderByMood = () => {
-    // TODO: Implement reorder by mood functionality
-    console.log("Reorder by mood for playlist:", currentPlaylist.id);
+    toast({
+      title: "Not implemented",
+      description: "Reorder by mood is coming soon",
+    });
   };
 
   return (

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -565,6 +565,74 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.post("/api/playlists/:id/add-similar", async (req, res) => {
+    try {
+      if (!req.session.userId) {
+        return res.status(401).json({ message: "Not authenticated" });
+      }
+
+      const playlistId = parseInt(req.params.id);
+      const playlist = await storage.getPlaylistWithTracks(playlistId);
+      if (!playlist || playlist.userId !== req.session.userId) {
+        return res.status(404).json({ message: "Playlist not found" });
+      }
+
+      const user = await storage.getUser(req.session.userId);
+      if (!user) {
+        return res.status(404).json({ message: "User not found" });
+      }
+
+      const currentTracks = playlist.tracks.map(t => ({
+        name: t.name,
+        artist: t.artist,
+        album: t.album,
+      }));
+
+      const ai = await modifyPlaylist({
+        action: "add_similar",
+        currentTracks,
+      });
+
+      const newTracks: any[] = [];
+      const existing = new Set(playlist.tracks.map(t => t.spotifyId));
+      for (const query of (ai.searchQueries ?? []).slice(0, 5)) {
+        const results = await spotifyService.searchTracks(user.accessToken, query, 3);
+        for (const track of results) {
+          if (!existing.has(track.id)) {
+            newTracks.push(track);
+            existing.add(track.id);
+          }
+          if (newTracks.length >= 10) break;
+        }
+        if (newTracks.length >= 10) break;
+      }
+
+      const startPos = playlist.tracks.length;
+      for (let i = 0; i < newTracks.length; i++) {
+        const track = newTracks[i];
+        await storage.addTrackToPlaylist({
+          playlistId,
+          spotifyId: track.id,
+          name: track.name,
+          artist: track.artists[0]?.name || "Unknown Artist",
+          album: track.album.name,
+          duration: track.duration_ms,
+          imageUrl: track.album.images[0]?.url || null,
+          previewUrl: track.preview_url,
+          position: startPos + i,
+        });
+      }
+
+      await storage.updatePlaylist(playlistId, { trackCount: startPos + newTracks.length });
+
+      const updated = await storage.getPlaylistWithTracks(playlistId);
+      res.json({ playlist: updated, reasoning: ai.reasoning });
+    } catch (error) {
+      console.error("Add similar songs error:", error);
+      res.status(500).json({ message: "Failed to add similar songs" });
+    }
+  });
+
   const httpServer = createServer(app);
   return httpServer;
 }


### PR DESCRIPTION
## Summary
- implement `/api/playlists/:id/add-similar` to call OpenAI and Spotify
- wire up Add Similar Songs button to use the new endpoint

## Testing
- `npm run check` *(fails: TS2495 in server/routes.ts and duplicate function implementations in spotify.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68795eb05ce483319baa414c1c697709