### PR TITLE
Improve Electron desktop app

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, shell } = require('electron');
 const path = require('path');
 const { spawn } = require('child_process');
 
@@ -12,11 +12,30 @@ function createWindow() {
     },
   });
 
+  // Open the developer tools automatically in development
+  if (process.env.NODE_ENV === 'development') {
+    win.webContents.openDevTools({ mode: 'detach' });
+  }
+
+  // Open external links in the user's default browser
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
   if (process.env.NODE_ENV === 'development') {
     win.loadURL('http://localhost:5173');
   } else {
     win.loadFile(path.join(__dirname, '../dist/client/index.html'));
   }
+
+  // Prevent navigation outside the app
+  win.webContents.on('will-navigate', (event, url) => {
+    if (url !== win.webContents.getURL()) {
+      event.preventDefault();
+      shell.openExternal(url);
+    }
+  });
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- open developer tools automatically in development
- open external links in the user's default browser
- block in-app navigation to external URLs

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687962b7a1248331a828676cd9515005