### PR TITLE
Implement follow-up prompts and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ An intelligent playlist generation tool that creates custom Spotify playlists us
 - **Smart Curation**: Intelligent track selection based on context and preferences
 - **Modern UI**: Clean, responsive interface with Spotify-inspired design
 - **Real-time Processing**: Fast playlist generation with live progress updates
+- **Follow-up Prompts**: Refine an existing playlist using additional prompts
+- **Emoji Mood Detection**: Prompts containing emojis automatically set the vibe
+- **Synonym Support**: Words like "hype" or "banger" imply high energy
+- **Cover Art Suggestions**: GPT proposes ideas for playlist artwork
+- **Export Tools**: Download playlists as JSON, CSV, or plain text
 
 ## Tech Stack
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
+        "cors": "^2.8.5",
         "date-fns": "^3.6.0",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
@@ -5519,6 +5520,19 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/crc": {
       "version": "3.8.0",


### PR DESCRIPTION
## Summary
- support high-energy synonyms and emoji mood detection in prompts
- generate cover art prompts from GPT results
- support follow-up prompts for existing playlists
- allow exporting playlist metadata
- document new user features

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6879631b32548331ab5650726cf42b30