### PR TITLE
Add AI assistant overlay

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import MaximalistHome from "@/pages/maximalist-home";
 import NotFound from "@/pages/not-found";
+import AiAssistant from "@/components/ai-assistant";
 
 function Router() {
   return (
@@ -22,6 +23,7 @@ function App() {
         <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-violet-900 text-white">
           <Toaster />
           <Router />
+          <AiAssistant />
         </div>
       </TooltipProvider>
     </QueryClientProvider>

--- a/client/src/components/ai-assistant.tsx
+++ b/client/src/components/ai-assistant.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+interface Message {
+  from: "user" | "ai";
+  text: string;
+}
+
+export default function AiAssistant() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const text = input.trim();
+    setMessages((m) => [...m, { from: "user", text }]);
+    setInput("");
+    try {
+      const res = await fetch("/api/assistant", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: text }),
+      });
+      const data = await res.json();
+      setMessages((m) => [...m, { from: "ai", text: data.response }]);
+    } catch (err) {
+      setMessages((m) => [...m, { from: "ai", text: "Sorry, an error occurred." }]);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        onClick={() => setOpen(!open)}
+        className="fixed bottom-4 right-4 z-50"
+        variant="secondary"
+      >
+        {open ? "Close Help" : "AI Help"}
+      </Button>
+      {open && (
+        <div className="fixed bottom-20 right-4 w-80 bg-background border border-border rounded-md p-3 z-50 shadow-lg">
+          <div className="max-h-60 overflow-y-auto space-y-2 mb-2 text-sm">
+            {messages.map((msg, idx) => (
+              <div key={idx} className={msg.from === "user" ? "text-right" : "text-left"}>
+                <span className="whitespace-pre-wrap">{msg.text}</span>
+              </div>
+            ))}
+          </div>
+          <Textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Ask how to use features..."
+            className="mb-2"
+            rows={3}
+          />
+          <Button onClick={sendMessage} className="w-full" size="sm">
+            Send
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { spotifyService } from "./services/spotify";
-import { generatePlaylistFromPrompt, generateAdvancedPlaylistFromPrompt, modifyPlaylist, get_playlist_criteria_from_prompt } from "./services/openai";
+import { generatePlaylistFromPrompt, generateAdvancedPlaylistFromPrompt, modifyPlaylist, get_playlist_criteria_from_prompt, assistantExplainFeatures } from "./services/openai";
 import { PlaylistEditor } from "./services/playlist-editor";
 import { updateTrackSchema } from "@shared/schema";
 import { z } from "zod";
@@ -83,6 +83,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
       });
     } catch (error) {
       res.status(500).json({ message: "Failed to get user profile" });
+    }
+  });
+
+  app.post("/api/assistant", async (req, res) => {
+    try {
+      const { message } = z.object({ message: z.string().min(1).max(500) }).parse(req.body);
+      const reply = await assistantExplainFeatures(message);
+      res.json({ response: reply });
+    } catch (error) {
+      console.error("Assistant error:", error);
+      res.status(500).json({ message: "Failed to generate assistant response" });
     }
   });
 

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -293,3 +293,16 @@ If segmented mode is enabled, create distinct sections with different characteri
     throw new Error("Failed to generate advanced playlist: " + (error as Error).message);
   }
 }
+
+export async function assistantExplainFeatures(question: string): Promise<string> {
+  const systemPrompt = `You are the Promptify AI assistant. Explain how to use the application's features in clear, concise language. Help users understand the interface and available options.`;
+  const response = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: question }
+    ],
+    temperature: 0.7,
+  });
+  return response.choices[0].message.content || "";
+}


### PR DESCRIPTION
## Summary
- add new function `assistantExplainFeatures` in OpenAI service to generate help text
- expose `/api/assistant` route for AI-powered help
- include `AiAssistant` component and render in app
- create floating AI help widget

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879644e5bb88331aa3df79aac925260