### PR TITLE
Use SPOTIFY_REDIRECT_URI environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DATABASE_URL=postgresql://user:password@localhost:5432/promptify
 # Spotify API Configuration
 SPOTIFY_CLIENT_ID=your_spotify_client_id_here
 SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here
+# Redirect URL set in your Spotify dashboard
 SPOTIFY_REDIRECT_URI=http://localhost:5000/api/auth/spotify/callback
 
 # OpenAI API Configuration

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ npm install
    - `DATABASE_URL` – connection string to your PostgreSQL database
    - `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` – from the Spotify
      Developer Dashboard
-   - `SPOTIFY_REDIRECT_URI` – OAuth callback URL
+   - `SPOTIFY_REDIRECT_URI` – OAuth callback URL (must match exactly what you set
+     in the Spotify Developer Dashboard)
    - `OPENAI_API_KEY` – your OpenAI API key
    - `SESSION_SECRET` – any random string
 
@@ -97,6 +98,8 @@ Open <http://localhost:5000> in your browser and you should see Promptify.
 1. Go to [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)
 2. Create a new app
 3. Add redirect URI: `http://localhost:5000/api/auth/spotify/callback`
+   - Use this exact value (or your deployed URL) in the `SPOTIFY_REDIRECT_URI`
+     setting in your `.env` file
 4. Copy your Client ID and Client Secret to your `.env` file
 
 ## Usage

--- a/server/services/spotify.ts
+++ b/server/services/spotify.ts
@@ -38,8 +38,12 @@ export class SpotifyService {
   constructor() {
     this.clientId = process.env.SPOTIFY_CLIENT_ID || "";
     this.clientSecret = process.env.SPOTIFY_CLIENT_SECRET || "";
-    // Use the exact redirect URI from your Spotify app settings
-    this.redirectUri = "https://40b819fa-7b5c-4452-9a74-ed7a3167e37d-00-9g1xwfbar0b6.picard.replit.dev/callback";
+
+    const uri = process.env.SPOTIFY_REDIRECT_URI;
+    if (!uri) {
+      throw new Error("SPOTIFY_REDIRECT_URI environment variable is not defined");
+    }
+    this.redirectUri = uri;
   }
 
   getAuthUrl(): string {


### PR DESCRIPTION
## Summary
- read `SPOTIFY_REDIRECT_URI` in spotify service
- throw an error when not provided
- document the env var in README and `.env.example`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687964b5481483319b851fa2dfa20d72