### PR TITLE
Fix Spotify callback route

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -26,7 +26,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.get("/callback", async (req, res) => {
+  app.get("/api/auth/spotify/callback", async (req, res) => {
     try {
       const { code } = req.query;
       if (!code) {

--- a/server/services/spotify.ts
+++ b/server/services/spotify.ts
@@ -39,7 +39,7 @@ export class SpotifyService {
     this.clientId = process.env.SPOTIFY_CLIENT_ID || "";
     this.clientSecret = process.env.SPOTIFY_CLIENT_SECRET || "";
     // Use the exact redirect URI from your Spotify app settings
-    this.redirectUri = "https://40b819fa-7b5c-4452-9a74-ed7a3167e37d-00-9g1xwfbar0b6.picard.replit.dev/callback";
+    this.redirectUri = process.env.SPOTIFY_REDIRECT_URI || "http://localhost:5000/api/auth/spotify/callback";
   }
 
   getAuthUrl(): string {


### PR DESCRIPTION
## Summary
- update the Spotify OAuth callback endpoint to `/api/auth/spotify/callback`
- load redirect URI from `SPOTIFY_REDIRECT_URI` env var

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687964b7028883319d863eeb1d57c181