### PR TITLE
Remove OpenAI API key fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npm install
    - `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` – from the Spotify
      Developer Dashboard
    - `SPOTIFY_REDIRECT_URI` – OAuth callback URL
-   - `OPENAI_API_KEY` – your OpenAI API key
+   - Either `OPENAI_API_KEY` or `OPENAI_API_KEY_ENV_VAR` must provide your OpenAI API key (the app will fail to start if neither is set)
    - `SESSION_SECRET` – any random string
 
 ### 4. Database Setup

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -1,8 +1,14 @@
 import OpenAI from "openai";
 
 // the newest OpenAI model is "gpt-4o" which was released May 13, 2024. do not change this unless explicitly requested by the user
+const apiKey = process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY_ENV_VAR;
+if (!apiKey) {
+  throw new Error(
+    "OpenAI API key not found. Set OPENAI_API_KEY or OPENAI_API_KEY_ENV_VAR"
+  );
+}
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY_ENV_VAR || "default_key"
+  apiKey
 });
 
 const energySynonyms = ["hype", "banger", "turn up"]; // words implying high energy


### PR DESCRIPTION
## Summary
- throw an error if the OpenAI API key env vars are missing
- document that either `OPENAI_API_KEY` or `OPENAI_API_KEY_ENV_VAR` is required

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687964b8e2f483319e073a861b5f1ccc