### PR TITLE
Add prompt suggestion endpoint and UI

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { spotifyService } from "./services/spotify";
-import { generatePlaylistFromPrompt, generateAdvancedPlaylistFromPrompt, modifyPlaylist, get_playlist_criteria_from_prompt, assistantExplainFeatures } from "./services/openai";
+import { generatePlaylistFromPrompt, generateAdvancedPlaylistFromPrompt, modifyPlaylist, get_playlist_criteria_from_prompt, assistantExplainFeatures, suggestPromptCompletions } from "./services/openai";
 import { PlaylistEditor } from "./services/playlist-editor";
 import { updateTrackSchema } from "@shared/schema";
 import { z } from "zod";
@@ -94,6 +94,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Assistant error:", error);
       res.status(500).json({ message: "Failed to generate assistant response" });
+    }
+  });
+
+  app.get("/api/prompts/suggest", async (req, res) => {
+    try {
+      const text = z.string().min(1).max(100).parse(req.query.text);
+      const suggestions = await suggestPromptCompletions(text);
+      res.json({ suggestions });
+    } catch (error) {
+      console.error("Prompt suggest error:", error);
+      res.status(500).json({ message: "Failed to get suggestions" });
     }
   });
 

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -354,3 +354,25 @@ export async function assistantExplainFeatures(question: string): Promise<string
   });
   return response.choices[0].message.content || "";
 }
+
+export async function suggestPromptCompletions(text: string): Promise<string[]> {
+  const systemPrompt =
+    "You suggest short playlist prompt completions. Return a JSON array of concise suggestions.";
+  const response = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: text }
+    ],
+    response_format: { type: "json_object" },
+    temperature: 0.7,
+  });
+
+  const content = response.choices[0].message.content || "[]";
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) return parsed;
+    if (Array.isArray(parsed.suggestions)) return parsed.suggestions;
+  } catch {}
+  return [];
+}


### PR DESCRIPTION
## Summary
- add suggestion helper in OpenAI service
- expose `/api/prompts/suggest` endpoint
- show prompt completions when typing in playlist generator

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6879662b86f48331946fbc9766955e9a