### PR TITLE
Implement playlist cover generation

### DIFF
--- a/client/src/components/playlist-display.tsx
+++ b/client/src/components/playlist-display.tsx
@@ -63,6 +63,28 @@ export default function PlaylistDisplay() {
     },
   });
 
+  const generateCover = useMutation({
+    mutationFn: async (id: number) => {
+      const res = await apiRequest("POST", `/api/playlists/${id}/generate-cover`);
+      return res.json();
+    },
+    onSuccess: (data) => {
+      if (currentPlaylist) {
+        const updated = { ...currentPlaylist, imageUrl: data.imageUrl };
+        setPlaylistState(updated);
+        queryClient.setQueryData(["/api/playlists", "current"], updated);
+      }
+      toast({ title: "Cover generated!" });
+    },
+    onError: (err: any) => {
+      toast({
+        title: "Failed to generate cover",
+        description: err.message,
+        variant: "destructive",
+      });
+    },
+  });
+
   if (isLoading) {
     return (
       <div className="spotify-gray rounded-xl p-6 mb-8">
@@ -117,6 +139,13 @@ export default function PlaylistDisplay() {
               className="spotify-lightgray hover-spotify-gray text-white p-2 rounded-full transition-colors"
             >
               <i className="fas fa-redo"></i>
+            </Button>
+            <Button
+              onClick={() => generateCover.mutate(currentPlaylist.id)}
+              disabled={generateCover.isPending}
+              className="spotify-lightgray hover-spotify-gray text-white p-2 rounded-full transition-colors"
+            >
+              <i className="fas fa-image"></i>
             </Button>
           </div>
         </div>

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -354,3 +354,20 @@ export async function assistantExplainFeatures(question: string): Promise<string
   });
   return response.choices[0].message.content || "";
 }
+
+export async function generateCoverImage(prompt: string): Promise<string> {
+  try {
+    const result = await openai.images.generate({
+      model: "dall-e-3",
+      prompt,
+      n: 1,
+      size: "1024x1024",
+    });
+    const url = result.data?.[0]?.url;
+    if (!url) throw new Error("No image URL returned");
+    return url;
+  } catch (error) {
+    console.error("OpenAI image generation error:", error);
+    throw new Error("Failed to generate cover image: " + (error as Error).message);
+  }
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -21,6 +21,7 @@ export const playlists = pgTable("playlists", {
   name: text("name").notNull(),
   description: text("description"),
   prompt: text("prompt").notNull(),
+  coverArtPrompt: text("cover_art_prompt"),
   imageUrl: text("image_url"),
   trackCount: integer("track_count").default(0),
   isPublic: boolean("is_public").default(false),


### PR DESCRIPTION
## Summary
- store `coverArtPrompt` in playlists
- add OpenAI helper to create cover images
- expose `/api/playlists/:id/generate-cover` route
- add button to trigger cover art generation

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6879662a718c833187c9da619b709062