### PR TITLE
Add user preferences management

### DIFF
--- a/client/src/components/preferences-panel.tsx
+++ b/client/src/components/preferences-panel.tsx
@@ -1,0 +1,80 @@
+import { useState, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { preferencesApi } from "@/lib/api";
+
+export default function PreferencesPanel() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const { data } = useQuery<any>({
+    queryKey: ["/api/preferences"],
+    queryFn: preferencesApi.get,
+  });
+
+  const [genres, setGenres] = useState("");
+  const [artists, setArtists] = useState("");
+  const [bannedTerms, setBannedTerms] = useState("");
+  const [bannedArtists, setBannedArtists] = useState("");
+  const [bannedGenres, setBannedGenres] = useState("");
+
+  useEffect(() => {
+    if (data) {
+      setGenres((data.favoriteGenres || []).join(", "));
+      setArtists((data.favoriteArtists || []).join(", "));
+      setBannedTerms((data.bannedTerms || []).join(", "));
+      setBannedArtists((data.bannedArtists || []).join(", "));
+      setBannedGenres((data.bannedGenres || []).join(", "));
+    }
+  }, [data]);
+
+  const savePrefs = useMutation({
+    mutationFn: async () => {
+      const payload = {
+        favoriteGenres: genres.split(",").map(s => s.trim()).filter(Boolean),
+        favoriteArtists: artists.split(",").map(s => s.trim()).filter(Boolean),
+        bannedTerms: bannedTerms.split(",").map(s => s.trim()).filter(Boolean),
+        bannedArtists: bannedArtists.split(",").map(s => s.trim()).filter(Boolean),
+        bannedGenres: bannedGenres.split(",").map(s => s.trim()).filter(Boolean),
+      };
+      return preferencesApi.update(payload);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/preferences"] });
+      toast({ title: "Preferences saved" });
+    },
+    onError: (err: any) => {
+      toast({ title: "Failed to save", description: err.message, variant: "destructive" });
+    }
+  });
+
+  return (
+    <div className="spotify-gray rounded-xl p-6 space-y-4">
+      <h2 className="text-xl font-bold">Preferences</h2>
+      <div>
+        <label className="text-sm">Favorite Genres</label>
+        <Input value={genres} onChange={e => setGenres(e.target.value)} placeholder="rock, pop" />
+      </div>
+      <div>
+        <label className="text-sm">Favorite Artists</label>
+        <Input value={artists} onChange={e => setArtists(e.target.value)} placeholder="artist names" />
+      </div>
+      <div>
+        <label className="text-sm">Banned Terms</label>
+        <Input value={bannedTerms} onChange={e => setBannedTerms(e.target.value)} placeholder="explicit words" />
+      </div>
+      <div>
+        <label className="text-sm">Banned Artists</label>
+        <Input value={bannedArtists} onChange={e => setBannedArtists(e.target.value)} placeholder="artists to exclude" />
+      </div>
+      <div>
+        <label className="text-sm">Banned Genres</label>
+        <Input value={bannedGenres} onChange={e => setBannedGenres(e.target.value)} placeholder="genres to exclude" />
+      </div>
+      <Button onClick={() => savePrefs.mutate()} disabled={savePrefs.isPending}>
+        {savePrefs.isPending ? "Saving..." : "Save"}
+      </Button>
+    </div>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -64,3 +64,14 @@ export const promptApi = {
     return response.json();
   },
 };
+
+export const preferencesApi = {
+  async get() {
+    const res = await apiRequest("GET", "/api/preferences");
+    return res.json();
+  },
+  async update(data: any) {
+    const res = await apiRequest("PUT", "/api/preferences", data);
+    return res.json();
+  },
+};

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -7,6 +7,7 @@ import Sidebar from "@/components/sidebar";
 import Header from "@/components/header";
 import PromptGenerator from "@/components/prompt-generator";
 import PlaylistDisplay from "@/components/playlist-display";
+import PreferencesPanel from "@/components/preferences-panel";
 
 export default function Home() {
   const [location] = useLocation();
@@ -141,6 +142,7 @@ export default function Home() {
                 )}
               </div>
             </div>
+            <PreferencesPanel />
           </div>
         </div>
       </main>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,7 +4,7 @@ import { storage } from "./storage";
 import { spotifyService } from "./services/spotify";
 import { generatePlaylistFromPrompt, generateAdvancedPlaylistFromPrompt, modifyPlaylist, get_playlist_criteria_from_prompt, assistantExplainFeatures } from "./services/openai";
 import { PlaylistEditor } from "./services/playlist-editor";
-import { updateTrackSchema } from "@shared/schema";
+import { updateTrackSchema, type InsertUserPreferences } from "@shared/schema";
 import { z } from "zod";
 
 // Extend express session to include userId
@@ -86,6 +86,33 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/preferences", async (req, res) => {
+    try {
+      if (!req.session.userId) {
+        return res.status(401).json({ message: "Not authenticated" });
+      }
+
+      const prefs = await storage.getUserPreferences(req.session.userId);
+      res.json(prefs || {});
+    } catch (error) {
+      res.status(500).json({ message: "Failed to load preferences" });
+    }
+  });
+
+  app.put("/api/preferences", async (req, res) => {
+    try {
+      if (!req.session.userId) {
+        return res.status(401).json({ message: "Not authenticated" });
+      }
+
+      const prefs = req.body as InsertUserPreferences;
+      const updated = await storage.setUserPreferences(req.session.userId, prefs);
+      res.json(updated);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to update preferences" });
+    }
+  });
+
   app.post("/api/assistant", async (req, res) => {
     try {
       const { message } = z.object({ message: z.string().min(1).max(500) }).parse(req.body);
@@ -115,12 +142,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: "User not found" });
       }
 
+      const userPrefs = await storage.getUserPreferences(user.id);
+
       const debug = req.query.debug === 'true';
 
       // Generate playlist metadata with OpenAI
       const playlistData = await generatePlaylistFromPrompt({
         prompt,
         userId: user.id,
+        preferences: userPrefs || undefined,
       });
       const criteria = await get_playlist_criteria_from_prompt(prompt);
 
@@ -228,14 +258,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       const config = req.body;
-      
+
       const user = await storage.getUser(req.session.userId);
       if (!user) {
         return res.status(404).json({ message: "User not found" });
       }
 
+      const userPrefs = await storage.getUserPreferences(user.id);
+
       // Generate playlist with advanced configuration
-      const playlistData = await generateAdvancedPlaylistFromPrompt(config);
+      const playlistData = await generateAdvancedPlaylistFromPrompt(config, userPrefs || undefined);
 
       // Search for tracks using Spotify API with advanced filters
       const tracks: any[] = [];

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -128,6 +128,17 @@ export const recentPrompts = pgTable("recent_prompts", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
+export const userPreferences = pgTable("user_preferences", {
+  userId: integer("user_id").references(() => users.id).primaryKey(),
+  favoriteGenres: jsonb("favorite_genres"),
+  favoriteArtists: jsonb("favorite_artists"),
+  bannedTerms: jsonb("banned_terms"),
+  bannedArtists: jsonb("banned_artists"),
+  bannedGenres: jsonb("banned_genres"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
 export const insertUserSchema = createInsertSchema(users).omit({
   id: true,
   createdAt: true,
@@ -153,6 +164,12 @@ export const insertRecentPromptSchema = createInsertSchema(recentPrompts).omit({
   createdAt: true,
 });
 
+export const insertUserPreferencesSchema = createInsertSchema(userPreferences).omit({
+  userId: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
 export type User = typeof users.$inferSelect;
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type Playlist = typeof playlists.$inferSelect;
@@ -162,6 +179,8 @@ export type InsertTrack = z.infer<typeof insertTrackSchema>;
 export type UpdateTrack = z.infer<typeof updateTrackSchema>;
 export type RecentPrompt = typeof recentPrompts.$inferSelect;
 export type InsertRecentPrompt = z.infer<typeof insertRecentPromptSchema>;
+export type UserPreferences = typeof userPreferences.$inferSelect;
+export type InsertUserPreferences = z.infer<typeof insertUserPreferencesSchema>;
 
 export interface PlaylistWithTracks extends Playlist {
   tracks: Track[];


### PR DESCRIPTION
## Summary
- support a new `user_preferences` table
- expose storage CRUD and `/api/preferences` endpoints
- include preferences in playlist generation prompts
- add PreferencesPanel to edit settings

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6879662ce7488331b580e44b6abbd70c