### PR TITLE
Add Spotify playlist import and advanced editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An intelligent playlist generation tool that creates custom Spotify playlists us
 - **Synonym Support**: Words like "hype" or "banger" imply high energy
 - **Cover Art Suggestions**: GPT proposes ideas for playlist artwork
 - **Export Tools**: Download playlists as JSON, CSV, or plain text
+- **Import & Edit**: Load any Spotify playlist by ID or URL and apply advanced AI-driven modifications
 
 ## Tech Stack
 
@@ -112,6 +113,7 @@ Open <http://localhost:5000> in your browser and you should see Promptify.
 - "I need epic workout music with heavy bass and high energy"
 - "Make me a nostalgic 90s road trip playlist"
 - "Dark villain origin story vibes with haunting melodies"
+- "Import a Spotify playlist then say: Remove sad songs and make this more upbeat"
 
 ## Development
 

--- a/server/services/spotify.ts
+++ b/server/services/spotify.ts
@@ -277,6 +277,31 @@ export class SpotifyService {
     return data.items.map((item: any) => item.track);
   }
 
+  parsePlaylistId(idOrUrl: string): string {
+    if (idOrUrl.includes('spotify.com')) {
+      const match = idOrUrl.match(/playlist\/(\w+)/);
+      if (match) return match[1];
+    }
+    if (idOrUrl.startsWith('spotify:playlist:')) {
+      return idOrUrl.split(':')[2];
+    }
+    return idOrUrl;
+  }
+
+  async getPlaylist(accessToken: string, playlistId: string): Promise<SpotifyPlaylist> {
+    const response = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}`, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to get playlist: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
   async getAudioFeatures(accessToken: string, trackIds: string[]): Promise<any[]> {
     const ids = trackIds.join(',');
     const response = await fetch(`https://api.spotify.com/v1/audio-features?ids=${ids}`, {


### PR DESCRIPTION
## Summary
- support importing playlists by Spotify URL or ID
- allow advanced AI-powered playlist edits via `/api/playlists/:id/advanced-edit`
- document playlist import feature in README

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6879669500a48331b38d68545e94ebda