### PR TITLE
Add extended playlist filtering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An intelligent playlist generation tool that creates custom Spotify playlists us
 - **Synonym Support**: Words like "hype" or "banger" imply high energy
 - **Cover Art Suggestions**: GPT proposes ideas for playlist artwork
 - **Export Tools**: Download playlists as JSON, CSV, or plain text
+- **Advanced Editing**: Filter by BPM, mood or artist, remove duplicates and non-English tracks
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary
- document advanced editing capabilities in README
- expand playlist editor with helper for detecting English titles
- extend command parser with new filter actions
- implement new filters: valence, BPM, artist, duplicates, keywords, language
- support sorting by valence

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687966c718b88331b41d905b993d3a1b