### PR TITLE
Update desktop app instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,27 @@ Use Electron to run Promptify as a native macOS application.
 1. `npm run electron:dev` to launch the app with the dev server.
 2. `npm run electron:pack` to create a macOS app bundle (requires macOS).
 
+### Downloading the Desktop App
+
+If you just want to use the macOS version without building it yourself:
+
+1. Visit the GitHub **Releases** page for this project.
+2. Download the latest `Promptify.dmg` file.
+3. Open the DMG and drag **Promptify** into your `Applications` folder.
+
+### Packaging a DMG Yourself
+
+If you are developing or want to build from source, you can create the DMG on a
+macOS machine:
+
+```bash
+npm install
+npm run electron:pack
+```
+
+The packaged `.dmg` will be available in the `dist/` directory. Open it and drag
+the **Promptify** app into `Applications` to install.
+
 ## Contributing
 
 1. Fork the repository

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "electron:dev": "NODE_ENV=development electron electron/main.js",
-    "electron:pack": "NODE_ENV=production npm run build && electron-builder --mac",
+    "electron:pack": "NODE_ENV=production npm run build && electron-builder --mac dmg",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- document how to download the DMG
- explain how to package the mac app into a DMG
- tweak the electron packaging script to explicitly build a DMG

## Testing
- `npm test` *(fails: Could not find declaration file for module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68796a688a0c8331ab68aa7de7271253