### PR TITLE
Add Neon workflow

### DIFF
--- a/.github/workflows/neon_workflow.yml
+++ b/.github/workflows/neon_workflow.yml
@@ -1,0 +1,25 @@
+name: Neon Branch per PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  manage-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create branch
+        if: github.event.action != 'closed'
+        uses: neondatabase/create-branch-action@v6
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          branch_name: ${{ github.head_ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
+      - name: Delete branch
+        if: github.event.action == 'closed'
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          branch: ${{ github.head_ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to create/delete Neon branches per PR

## Testing
- `npm test` *(fails: cannot find module 'supertest' and other Jest types)*

------
https://chatgpt.com/codex/tasks/task_e_68796abb206c8331872276c475f4d305