### PR TITLE
Add desktop app download section

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,14 +151,14 @@ Use Electron to run Promptify as a native macOS application.
 
 1. `npm run electron:dev` to launch the app with the dev server.
 2. `npm run electron:pack` to create a macOS app bundle (requires macOS).
-
-### Downloading the Desktop App
+## Downloading the Desktop App
 
 If you just want to use the macOS version without building it yourself:
 
 1. Visit the GitHub **Releases** page for this project.
 2. Download the latest `Promptify.dmg` file.
 3. Open the DMG and drag **Promptify** into your `Applications` folder.
+
 
 ### Packaging a DMG Yourself
 


### PR DESCRIPTION
## Summary
- document downloading the prebuilt DMG in its own section

## Testing
- `npm run test` *(fails: cannot find name 'describe')*

------
https://chatgpt.com/codex/tasks/task_e_68796bcdda5c833191a3bb5b3b82666a