### PR TITLE
Resolve import conflict and add prompt utils

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { spotifyService } from "./services/spotify";
+import { parsePromptFilters } from "./utils/prompt";
 import { generatePlaylistFromPrompt, generateAdvancedPlaylistFromPrompt, modifyPlaylist, get_playlist_criteria_from_prompt, assistantExplainFeatures, suggestPromptCompletions } from "./services/openai";
 import { PlaylistEditor } from "./services/playlist-editor";
 import { updateTrackSchema, type InsertUserPreferences } from "@shared/schema";

--- a/server/utils/prompt.ts
+++ b/server/utils/prompt.ts
@@ -1,0 +1,60 @@
+export interface PromptFilters {
+  includeGenres: string[];
+  excludeGenres: string[];
+  decadeFilters: string[];
+  explicit: boolean | null;
+}
+
+// Basic heuristic parser for playlist prompt filters
+export function parsePromptFilters(prompt: string): PromptFilters {
+  const includeGenres: string[] = [];
+  const excludeGenres: string[] = [];
+  const decadeFilters: string[] = [];
+  let explicit: boolean | null = null;
+
+  // check for explicit/clean mentions
+  if (/\bno explicit\b|\bclean version\b/i.test(prompt)) {
+    explicit = false;
+  } else if (/\bexplicit\b/i.test(prompt)) {
+    explicit = true;
+  }
+
+  // detect decade references like "80s" or "1990s"
+  const decadeRegex = /(\d{2})(?:\d{2})?s/gi;
+  let decadeMatch;
+  while ((decadeMatch = decadeRegex.exec(prompt)) !== null) {
+    const decade = decadeMatch[0];
+    if (!decadeFilters.includes(decade)) decadeFilters.push(decade);
+  }
+
+  // simple genre extraction for common genres
+  const commonGenres = [
+    "rock",
+    "pop",
+    "hip hop",
+    "jazz",
+    "electronic",
+    "metal",
+    "country",
+    "classical",
+    "lofi",
+    "indie",
+  ];
+
+  for (const genre of commonGenres) {
+    const regex = new RegExp(`\\b${genre}\\b`, "i");
+    if (regex.test(prompt)) {
+      includeGenres.push(genre);
+    }
+  }
+
+  // phrases like "no rock" to exclude genres
+  const excludeRegex = /no\s+(\w+)/gi;
+  let match;
+  while ((match = excludeRegex.exec(prompt)) !== null) {
+    const word = match[1].toLowerCase();
+    if (!excludeGenres.includes(word)) excludeGenres.push(word);
+  }
+
+  return { includeGenres, excludeGenres, decadeFilters, explicit };
+}


### PR DESCRIPTION
## Summary
- fix merge conflict in `server/routes.ts` by adding `parsePromptFilters` import
- implement a simple `parsePromptFilters` utility

## Testing
- `npm test` *(fails: cannot find name 'expect')*

------
https://chatgpt.com/codex/tasks/task_e_68796c354c3483318f721a09629f3974