### PR TITLE
Fix suggestion button text

### DIFF
--- a/client/src/components/prompt-generator.tsx
+++ b/client/src/components/prompt-generator.tsx
@@ -92,7 +92,7 @@ export default function PromptGenerator() {
               onClick={() => useSuggestion(suggestion)}
               className="spotify-lightgray hover-spotify-gray text-sm px-4 py-2 rounded-full transition-colors border-gray-600 hover:border-gray-500"
             >
-              "{suggestion}"
+              {suggestion}
             </Button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- fix text rendering for suggestion buttons

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687971ccb89c833199d7ef0ed09b37b5