### PR TITLE
Implement playlist editor API interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.1.1",
     "tsx": "^4.19.1",
-    "typescript": "5.6.3",
+    "typescript": "5.6.3"
 
   },
   "optionalDependencies": {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -507,10 +507,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(403).json({ message: "Not authorized to edit this playlist" });
       }
 
+      const user = await storage.getUser(req.session.userId);
+      if (!user) {
+        return res.status(404).json({ message: "User not found" });
+      }
+
       const result = await playlistEditor.processCommand({
         tracks: playlist.tracks,
         command,
-        userPreferences
+        userPreferences,
+        accessToken: user.accessToken
       });
 
       // Update playlist metadata


### PR DESCRIPTION
## Summary
- allow PlaylistEditor to accept an access token
- use Spotify/OpenAI APIs to replace tracks when transforming mood
- use Spotify/OpenAI APIs to search for new tracks when expanding playlists
- send user access token from `/api/playlists/:id/edit`
- fix trailing comma in `package.json`

## Testing
- `npm test` *(fails: SyntaxError in jest.config.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_687971d2073c8331af4d7d8ddfcb93d4